### PR TITLE
Refactor connection management to use an event bus

### DIFF
--- a/cmd/cortex_agent/main.go
+++ b/cmd/cortex_agent/main.go
@@ -52,9 +52,9 @@ func main() {
 	application := app.NewApp(*configFile, *jsonMode)
 	if err := application.Run(ctx); err != nil {
 		if errors.Is(err, context.Canceled) {
-			log.Println(i18n.T("app_context_terminated", nil))
+			log.Println(i18n.T("app_terminated", map[string]interface{}{"Reason": "context cancellation"}))
 		} else {
-			log.Fatalf(i18n.Tf("app_error", nil), i18n.T("app_error", map[string]interface{}{"Error": err}))
+			log.Fatalf("%s", i18n.T("app_error", map[string]interface{}{"Error": err}))
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,7 @@ require (
 	golang.org/x/text v0.24.0
 )
 
-require golang.org/x/sys v0.32.0 // indirect
+require (
+	golang.org/x/sync v0.13.0 // indirect
+	golang.org/x/sys v0.32.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/nicksnyder/go-i18n/v2 v2.6.0 h1:C/m2NNWNiTB6SK4Ao8df5EWm3JETSTIGNXBpM
 github.com/nicksnyder/go-i18n/v2 v2.6.0/go.mod h1:88sRqr0C6OPyJn0/KRNaEz1uWorjxIKP7rUUcvycecE=
 golang.org/x/crypto v0.37.0 h1:kJNSjF/Xp7kU0iB2Z+9viTPMW4EqqsrywMXLJOOsXSE=
 golang.org/x/crypto v0.37.0/go.mod h1:vg+k43peMZ0pUMhYmVAWysMK35e6ioLh3wB8ZCAfbVc=
+golang.org/x/sync v0.13.0 h1:AauUjRAJ9OSnvULf/ARrrVywoJDy0YS2AwQ98I37610=
+golang.org/x/sync v0.13.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
 golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/term v0.31.0 h1:erwDkOK1Msy6offm1mOgvspSkslFnIGsFnxOKoufg3o=

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,9 +1,7 @@
 package app
 
 import (
-	"context"
 	"testing"
-	"time"
 )
 
 func TestNewApp(t *testing.T) {
@@ -12,34 +10,43 @@ func TestNewApp(t *testing.T) {
 	if app == nil {
 		t.Fatal("Expected app to be non-nil")
 	}
-}
 
-func TestLoadConfig(t *testing.T) {
-	t.Skip("Need to mock ConfigService for proper testing")
-}
-
-func TestRunOnce(t *testing.T) {
-	t.Skip("Need to mock ConnectionService for proper testing")
-}
-
-func TestRunWithReconnect(t *testing.T) {
-	t.Skip("Need to mock dependencies for proper testing")
-}
-
-func TestExecuteConnection(t *testing.T) {
-	t.Skip("Need to mock SSH connection for proper testing")
-}
-
-func TestAppRunCancel(t *testing.T) {
-	t.Skip("Need to mock services for proper testing")
-
-	app := NewApp("test-config.toml", true)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
-	defer cancel()
-
-	err := app.Run(ctx)
-	if err == nil {
-		t.Fatal("Expected error due to context cancellation")
+	components := map[string]interface{}{
+		"configService":     app.configService,
+		"connectionService": app.connectionService,
+		"signalService":     app.signalService,
+		"eventBus":          app.eventBus,
 	}
+
+	for name, component := range components {
+		if component == nil {
+			t.Errorf("Expected %s to be non-nil", name)
+		}
+	}
+}
+
+func TestServices(t *testing.T) {
+	t.Run("StartServices", func(t *testing.T) {
+		t.Skip("Need to implement mock services")
+	})
+
+	t.Run("StopServices", func(t *testing.T) {
+		t.Skip("Need to implement mock services")
+	})
+
+	t.Run("RunOnce", func(t *testing.T) {
+		t.Skip("Need to implement mock ConnectionService")
+	})
+
+	t.Run("RunWithReconnect", func(t *testing.T) {
+		t.Skip("Need to implement mock services")
+	})
+
+	t.Run("AppRunCancel", func(t *testing.T) {
+		t.Skip("Need to implement mock services")
+	})
+
+	t.Run("TriggerReconnect", func(t *testing.T) {
+		t.Skip("Need to implement mock eventBus")
+	})
 }

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -93,9 +93,8 @@ func T(messageID string, templateData map[string]interface{}) string {
 	return msg
 }
 
-// Avoid Go's "non-constant format string" linter errors
 func Tf(messageID string, templateData map[string]interface{}) string {
-	return "%s"
+	return T(messageID, templateData)
 }
 
 func Tp(messageID string, pluralCount interface{}, templateData map[string]interface{}) string {

--- a/internal/i18n/locales/en.toml
+++ b/internal/i18n/locales/en.toml
@@ -21,9 +21,6 @@ other = "Failed to send configuration: {{.Error}}"
 [heartbeat_error]
 other = "Failed to send heartbeat: {{.Error}}"
 
-[app_terminating]
-other = "Application terminating due to context cancellation"
-
 [reconnecting]
 other = "Reconnecting due to configuration change..."
 
@@ -48,6 +45,7 @@ other = "Dialing SSH server {{.Host}}:{{.Port}}..."
 [ssh_connection_established]
 other = "SSH connection established"
 
+
 [ssh_server_auth]
 other = "Authenticating to server using public key"
 
@@ -58,8 +56,8 @@ other = "Warning: Failed to initialize localization: {{.Error}}"
 [pid_file_error]
 other = "Warning: Failed to write PID file: {{.Error}}"
 
-[app_context_terminated]
-other = "Application terminated due to context cancellation"
+[app_terminated]
+other = "Application terminated: {{.Reason}}"
 
 [app_error]
 other = "Application error: {{.Error}}"
@@ -80,9 +78,25 @@ other = "SIGHUP received, reloading configuration..."
 [config_reload_error]
 other = "Failed to reload configuration: {{.Error}}"
 
+[config_reload_requested]
+other = "Configuration reload requested"
+
+[config_reloading]
+other = "Reloading configuration..."
+
+[config_updating]
+other = "Updating configuration without reconnecting..."
+
+[config_update_failed]
+other = "Failed to update configuration: {{.Error}}. Will reconnect instead."
+
+[config_updated]
+other = "Configuration updated successfully."
+
+[config_sent]
+other = "Configuration sent to SSH server successfully."
+
 # JSON protocol
-[json_daemon_shutdown]
-other = "Context cancelled, shutting down daemon JSON mode..."
 
 [connection_closed]
 other = "Connection closed normally"
@@ -93,11 +107,7 @@ other = "Connection error: {{.Error}}"
 [reconnection_requested]
 other = "Reconnection requested"
 
-[reader_exiting]
-other = "Response reader goroutine exiting"
 
-[main_loop_exiting]
-other = "Main loop reader goroutine exiting"
 
 [decode_error]
 other = "Error decoding server response: {{.Error}}"
@@ -108,11 +118,7 @@ other = "Received response from server: {{.Response}}"
 [json_shutdown]
 other = "Context cancelled, shutting down JSON mode..."
 
-[input_closed]
-other = "Input stream closed"
 
-[context_cancelled_read]
-other = "Context cancelled during read"
 
 [response_no_writer]
 other = "Received response (no output writer): {{.Response}}"
@@ -120,8 +126,6 @@ other = "Received response (no output writer): {{.Response}}"
 [response_timeout]
 other = "Timeout waiting for response"
 
-[bytes_received]
-other = "Received {{.Count}} bytes from subsystem"
 
 # SSH connection
 [ssh_connect_failed]
@@ -173,14 +177,31 @@ other = "failed to write payload: {{.Error}}"
 [ssh_read_error]
 other = "failed to read from SSH connection: {{.Error}}"
 
-[stderr_reader_exiting]
-other = "Stderr reader goroutine exiting"
 
 [stderr_read_error]
 other = "Error reading stderr: {{.Error}}"
 
 [server_stderr]
 other = "Server stderr: {{.Output}}"
+
+# Service status messages
+[connection_established]
+other = "Connection established successfully"
+
+[connection_failed]
+other = "Connection failed"
+
+[app_termination_signal]
+other = "Termination signal received, shutting down application"
+
+[ssh_stderr_error]
+other = "Error reading from stderr: {{.Error}}"
+
+[stderr_received]
+other = "Received from stderr: {{.Data}}"
+
+[service_stop_error]
+other = "Error stopping {{.Service}} service: {{.Error}}"
 
 # Command-line flags and usage
 [usage_header]

--- a/internal/i18n/locales/es.toml
+++ b/internal/i18n/locales/es.toml
@@ -21,9 +21,6 @@ other = "Error al enviar la configuración: {{.Error}}"
 [heartbeat_error]
 other = "Error al enviar latido: {{.Error}}"
 
-[app_terminating]
-other = "La aplicación está terminando debido a la cancelación del contexto"
-
 [reconnecting]
 other = "Reconectando debido al cambio de configuración..."
 
@@ -48,6 +45,7 @@ other = "Marcando servidor SSH {{.Host}}:{{.Port}}..."
 [ssh_connection_established]
 other = "Conexión SSH establecida"
 
+
 [ssh_server_auth]
 other = "Autenticando en el servidor usando clave pública"
 
@@ -58,8 +56,8 @@ other = "Advertencia: No se pudo inicializar la localización: {{.Error}}"
 [pid_file_error]
 other = "Advertencia: No se pudo escribir el archivo PID: {{.Error}}"
 
-[app_context_terminated]
-other = "Aplicación terminada debido a la cancelación del contexto"
+[app_terminated]
+other = "Aplicación terminada: {{.Reason}}"
 
 [app_error]
 other = "Error de aplicación: {{.Error}}"
@@ -80,9 +78,25 @@ other = "SIGHUP recibido, recargando configuración..."
 [config_reload_error]
 other = "Error al recargar la configuración: {{.Error}}"
 
+[config_reload_requested]
+other = "Recarga de configuración solicitada"
+
+[config_reloading]
+other = "Recargando configuración..."
+
+[config_updating]
+other = "Actualizando configuración sin reconectar..."
+
+[config_update_failed]
+other = "Error al actualizar la configuración: {{.Error}}. Se reconectará en su lugar."
+
+[config_updated]
+other = "Configuración actualizada con éxito."
+
+[config_sent]
+other = "Configuración enviada al servidor SSH con éxito."
+
 # JSON protocol
-[json_daemon_shutdown]
-other = "Contexto cancelado, apagando el modo JSON del daemon..."
 
 [connection_closed]
 other = "Conexión cerrada normalmente"
@@ -93,11 +107,7 @@ other = "Error de conexión: {{.Error}}"
 [reconnection_requested]
 other = "Reconexión solicitada"
 
-[reader_exiting]
-other = "Goroutine del lector de respuestas finalizando"
 
-[main_loop_exiting]
-other = "Goroutine del lector del bucle principal finalizando"
 
 [decode_error]
 other = "Error al decodificar la respuesta del servidor: {{.Error}}"
@@ -108,11 +118,7 @@ other = "Respuesta recibida del servidor: {{.Response}}"
 [json_shutdown]
 other = "Contexto cancelado, apagando modo JSON..."
 
-[input_closed]
-other = "Flujo de entrada cerrado"
 
-[context_cancelled_read]
-other = "Contexto cancelado durante la lectura"
 
 [response_no_writer]
 other = "Respuesta recibida (sin escritor de salida): {{.Response}}"
@@ -120,8 +126,6 @@ other = "Respuesta recibida (sin escritor de salida): {{.Response}}"
 [response_timeout]
 other = "Tiempo de espera agotado para la respuesta"
 
-[bytes_received]
-other = "Recibidos {{.Count}} bytes del subsistema"
 
 # SSH connection
 [ssh_connect_failed]
@@ -173,14 +177,31 @@ other = "error al escribir la carga útil: {{.Error}}"
 [ssh_read_error]
 other = "error al leer de la conexión SSH: {{.Error}}"
 
-[stderr_reader_exiting]
-other = "Goroutine del lector de stderr finalizando"
 
 [stderr_read_error]
 other = "Error al leer stderr: {{.Error}}"
 
 [server_stderr]
 other = "Stderr del servidor: {{.Output}}"
+
+# Service status messages
+[connection_established]
+other = "Conexión establecida con éxito"
+
+[connection_failed]
+other = "Conexión fallida"
+
+[app_termination_signal]
+other = "Señal de terminación recibida, apagando la aplicación"
+
+[ssh_stderr_error]
+other = "Error al leer desde stderr: {{.Error}}"
+
+[stderr_received]
+other = "Recibido desde stderr: {{.Data}}"
+
+[service_stop_error]
+other = "Error al detener el servicio de {{.Service}}: {{.Error}}"
 
 # Command-line flags and usage
 [usage_header]

--- a/internal/protocol/common.go
+++ b/internal/protocol/common.go
@@ -4,32 +4,28 @@ import (
 	"context"
 	"errors"
 	"io"
-	"log"
 
-	"erlang-solutions.com/cortex_agent/internal/i18n"
 	"erlang-solutions.com/cortex_agent/internal/ssh"
 )
 
 func readStderr(ctx context.Context, conn ssh.Connection) {
-	defer log.Println(i18n.T("stderr_reader_exiting", nil))
-
 	buffer := make([]byte, 4096)
+
 	for {
 		select {
 		case <-ctx.Done():
 			return
+
 		default:
 			n, err := conn.Stderr().Read(buffer)
 			if err != nil {
 				if isExpectedError(err) {
 					return
 				}
-				log.Printf(i18n.Tf("stderr_read_error", nil), i18n.T("stderr_read_error", map[string]interface{}{"Error": err}))
 				return
 			}
-			if n > 0 {
-				log.Printf(i18n.Tf("server_stderr", nil), i18n.T("server_stderr", map[string]interface{}{"Output": string(buffer[:n])}))
-			}
+
+			_ = n
 		}
 	}
 }

--- a/internal/protocol/loop.go
+++ b/internal/protocol/loop.go
@@ -3,68 +3,90 @@ package protocol
 import (
 	"context"
 	"fmt"
-	"log"
+	"golang.org/x/sync/errgroup"
+	"time"
 
 	"erlang-solutions.com/cortex_agent/internal/i18n"
 	"erlang-solutions.com/cortex_agent/internal/ssh"
 )
 
 func RunMainLoop(ctx context.Context, conn ssh.Connection, reconnectCh <-chan struct{}) error {
-	errorCh := make(chan error, 1)
-
 	readCtx, cancelRead := context.WithCancel(ctx)
 	defer cancelRead()
 
-	go readData(readCtx, conn, errorCh)
-	go readStderr(readCtx, conn)
+	g, gCtx := errgroup.WithContext(readCtx)
 
-	for {
-		select {
-		case <-ctx.Done():
-			log.Println(i18n.T("json_shutdown", nil))
-			return ctx.Err()
-		case err := <-errorCh:
-			if isExpectedError(err) {
-				log.Println(i18n.T("connection_closed", nil))
+	dataErrCh := make(chan error, 1)
+
+	g.Go(func() error {
+		return readData(gCtx, conn, dataErrCh)
+	})
+
+	g.Go(func() error {
+		readStderr(gCtx, conn)
+		return nil
+	})
+
+	heartbeatTicker := time.NewTicker(30 * time.Second)
+	defer heartbeatTicker.Stop()
+
+	g.Go(func() error {
+		for {
+			select {
+			case <-gCtx.Done():
 				return nil
+			case <-heartbeatTicker.C:
+				if err := conn.SendPayload(map[string]string{"type": "heartbeat"}); err != nil {
+					return fmt.Errorf("heartbeat failed: %w", err)
+				}
 			}
-			log.Printf(i18n.Tf("connection_error_log", nil), i18n.T("connection_error_log", map[string]interface{}{"Error": err}))
-			return err
-		case <-reconnectCh:
-			log.Println(i18n.T("reconnection_requested", nil))
+		}
+	})
+
+	select {
+	case <-ctx.Done():
+		cancelRead()
+		_ = g.Wait()
+		return ctx.Err()
+
+	case err := <-dataErrCh:
+		cancelRead()
+		_ = g.Wait()
+		if isExpectedError(err) {
 			return nil
 		}
+		return err
+
+	case <-reconnectCh:
+		cancelRead()
+		_ = g.Wait()
+		return nil
 	}
 }
 
-func readData(ctx context.Context, conn ssh.Connection, errorCh chan<- error) {
-	defer log.Println(i18n.T("main_loop_exiting", nil))
-
+func readData(ctx context.Context, conn ssh.Connection, errorCh chan<- error) error {
 	buffer := make([]byte, 8192)
+
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return ctx.Err()
+
 		default:
 			n, err := conn.Stdout().Read(buffer)
 			if err != nil {
 				if isExpectedError(err) {
-					return
+					return nil
 				}
+
 				select {
 				case errorCh <- fmt.Errorf("%s", i18n.T("ssh_read_error", map[string]interface{}{"Error": err})):
 				case <-ctx.Done():
 				}
-				return
+				return err
 			}
 
-			if n > 0 {
-				log.Printf(i18n.Tf("bytes_received", nil), i18n.T("bytes_received", map[string]interface{}{"Count": n}))
-
-				// Process data received from server
-				// This is where you could add more sophisticated handling of server messages
-				// For now, we just log the receipt of data
-			}
+			_ = n
 		}
 	}
 }

--- a/internal/service/connection.go
+++ b/internal/service/connection.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"os"
+	"sync"
 	"time"
 
 	"erlang-solutions.com/cortex_agent/internal/config"
@@ -16,30 +16,105 @@ import (
 )
 
 type ConnectionService struct {
+	BaseService
 	jsonMode bool
+
+	mu     sync.Mutex
+	conn   ssh.Connection
+	config config.Config
 }
 
-func NewConnectionService(jsonMode bool) *ConnectionService {
+func NewConnectionService(jsonMode bool, bus *EventBus) *ConnectionService {
 	return &ConnectionService{
-		jsonMode: jsonMode,
+		BaseService: NewBaseService("connection", bus),
+		jsonMode:    jsonMode,
 	}
+}
+
+func (s *ConnectionService) Start(ctx context.Context) error {
+	if err := s.BaseService.Start(ctx); err != nil {
+		return err
+	}
+
+	configCh := s.bus.Subscribe(ConfigUpdated, 1)
+	s.Go(func() {
+		s.handleEvents(configCh)
+	})
+
+	return nil
 }
 
 func (s *ConnectionService) IsJSONMode() bool {
 	return s.jsonMode
 }
 
-func (s *ConnectionService) Connect(ctx context.Context, cfg config.Config) (ssh.Connection, error) {
-	conn, err := ssh.Connect(ctx, cfg)
-	if err != nil {
-		msg := i18n.T("connection_error", map[string]interface{}{"Error": err})
-		return nil, fmt.Errorf("%s", msg)
-	}
-	return conn, nil
+func (s *ConnectionService) SetConfig(cfg config.Config) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.config = cfg
 }
 
-func (s *ConnectionService) SendInitialConfig(conn ssh.Connection, cfg config.Config) error {
-	payload := ssh.ConfigPayload{
+func (s *ConnectionService) GetConfig() config.Config {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.config
+}
+
+func (s *ConnectionService) Connect(ctx context.Context, cfg config.Config) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.config = cfg
+
+	conn, err := ssh.Connect(ctx, cfg)
+	if err != nil {
+		s.bus.Publish(Event{Type: ConnectionFailed, Data: err})
+		return fmt.Errorf("%s", i18n.T("connection_error", map[string]interface{}{"Error": err}))
+	}
+
+	s.conn = conn
+
+	if err := s.sendConfig(conn, cfg); err != nil {
+		_ = s.conn.Close()
+		s.conn = nil
+		return err
+	}
+
+	s.bus.Publish(Event{Type: ConnectionEstablished})
+	s.Go(func() {
+		s.runConnectionLoop(ctx)
+	})
+
+	return nil
+}
+
+func (s *ConnectionService) HasConnection() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.conn != nil
+}
+
+func (s *ConnectionService) closeConnection() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.conn == nil {
+		return nil
+	}
+
+	_ = s.conn.Close()
+	s.conn = nil
+	s.bus.Publish(Event{Type: ConnectionClosed})
+
+	return nil
+}
+
+func (s *ConnectionService) sendConfig(conn ssh.Connection, cfg config.Config) error {
+	payload := struct {
+		Type        string                `json:"type"`
+		Application ssh.ApplicationConfig `json:"application"`
+		Agent       ssh.AgentConfig       `json:"agent"`
+	}{
+		Type: "config_update",
 		Application: ssh.ApplicationConfig{
 			Hostname: cfg.Application.Hostname,
 			Port:     cfg.Application.Port,
@@ -50,20 +125,74 @@ func (s *ConnectionService) SendInitialConfig(conn ssh.Connection, cfg config.Co
 	}
 
 	if err := conn.SendPayload(payload); err != nil {
-		msg := i18n.T("config_send_error", map[string]interface{}{"Error": err})
-		return fmt.Errorf("%s", msg)
+		return fmt.Errorf("%s", i18n.T("config_send_error", map[string]interface{}{"Error": err}))
 	}
 	return nil
 }
 
-func (s *ConnectionService) RunJSONMode(ctx context.Context, conn ssh.Connection) error {
+func (s *ConnectionService) handleEvents(configCh <-chan Event) {
+	for {
+		select {
+		case <-s.Context().Done():
+			return
+
+		case event, ok := <-configCh:
+			if !ok {
+				return
+			}
+
+			if event.Type == ConfigUpdated {
+				if cfg, ok := event.Data.(config.Config); ok {
+					s.SetConfig(cfg)
+
+					s.mu.Lock()
+					conn := s.conn
+					s.mu.Unlock()
+
+					if conn != nil {
+						if err := s.sendConfig(conn, cfg); err != nil {
+							s.bus.Publish(Event{Type: ReconnectRequested})
+						}
+					} else {
+						s.bus.Publish(Event{Type: ReconnectRequested})
+					}
+				}
+			}
+		}
+	}
+}
+
+func (s *ConnectionService) runConnectionLoop(ctx context.Context) {
+	s.mu.Lock()
+	conn := s.conn
+	jsonMode := s.jsonMode
+	s.mu.Unlock()
+
+	if conn == nil {
+		return
+	}
+
+	var err error
+	if jsonMode {
+		err = s.runJSONMode(ctx, conn)
+	} else {
+		err = s.runStandardMode(ctx, conn)
+	}
+
+	if err != nil && !isKnownGoodError(err) {
+		s.bus.Publish(Event{Type: ConnectionFailed, Data: err})
+	}
+
+	_ = s.closeConnection()
+}
+
+func (s *ConnectionService) runJSONMode(ctx context.Context, conn ssh.Connection) error {
 	heartbeatTicker := time.NewTicker(30 * time.Second)
 	defer heartbeatTicker.Stop()
 
 	errCh := make(chan error, 1)
 	go func() {
-		err := protocol.HandleJSONMode(ctx, conn, os.Stdin, os.Stdout)
-		errCh <- err
+		errCh <- protocol.HandleJSONMode(ctx, conn, os.Stdin, os.Stdout)
 	}()
 
 	for {
@@ -71,33 +200,47 @@ func (s *ConnectionService) RunJSONMode(ctx context.Context, conn ssh.Connection
 		case <-ctx.Done():
 			return ctx.Err()
 		case err := <-errCh:
-			if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, context.Canceled) {
-				msg := i18n.T("json_mode_error", map[string]interface{}{"Error": err})
-				return fmt.Errorf("%s", msg)
+			if err != nil && !isKnownGoodError(err) {
+				return fmt.Errorf("%s", i18n.T("json_mode_error", map[string]interface{}{"Error": err}))
 			}
 			return err
 		case <-heartbeatTicker.C:
-			err := conn.SendPayload(map[string]string{"type": "heartbeat"})
-			if err != nil {
-				msg := i18n.T("heartbeat_error", map[string]interface{}{"Error": err})
-				log.Printf("%s", msg)
-			}
+			_ = conn.SendPayload(map[string]string{"type": "heartbeat"})
 		}
 	}
 }
 
-func (s *ConnectionService) RunStandardMode(ctx context.Context, conn ssh.Connection, reconnectCh <-chan struct{}) error {
-	err := protocol.RunMainLoop(ctx, conn, reconnectCh)
-	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, context.Canceled) {
-		msg := i18n.T("main_loop_error", map[string]interface{}{"Error": err})
-		return fmt.Errorf("%s", msg)
+func (s *ConnectionService) runStandardMode(ctx context.Context, conn ssh.Connection) error {
+	runCtx, cancelRun := context.WithCancel(ctx)
+	defer cancelRun()
+
+	reconnectCh := s.bus.Subscribe(ReconnectRequested, 1)
+	reconnectPassthrough := make(chan struct{}, 1)
+
+	go func() {
+		select {
+		case <-runCtx.Done():
+			return
+		case <-reconnectCh:
+			select {
+			case reconnectPassthrough <- struct{}{}:
+			default:
+			}
+			cancelRun()
+		}
+	}()
+
+	err := protocol.RunMainLoop(runCtx, conn, reconnectPassthrough)
+
+	if err != nil && !isKnownGoodError(err) {
+		return fmt.Errorf("%s", i18n.T("main_loop_error", map[string]interface{}{"Error": err}))
 	}
+
 	return nil
 }
 
-func (s *ConnectionService) Run(ctx context.Context, conn ssh.Connection, reconnectCh <-chan struct{}) error {
-	if s.jsonMode {
-		return s.RunJSONMode(ctx, conn)
-	}
-	return s.RunStandardMode(ctx, conn, reconnectCh)
+func isKnownGoodError(err error) bool {
+	return err == nil ||
+		errors.Is(err, context.Canceled) ||
+		errors.Is(err, io.EOF)
 }

--- a/internal/service/connection_test.go
+++ b/internal/service/connection_test.go
@@ -1,54 +1,142 @@
 package service
 
 import (
+	"context"
 	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	"erlang-solutions.com/cortex_agent/internal/config"
 	"erlang-solutions.com/cortex_agent/internal/ssh"
 )
 
-func TestConnectionServiceIsJSONMode(t *testing.T) {
-	svc := NewConnectionService(true)
-	if !svc.IsJSONMode() {
-		t.Error("Expected IsJSONMode() to return true")
-	}
+func TestConnectionService(t *testing.T) {
+	t.Run("JSONMode", func(t *testing.T) {
+		bus := NewEventBus()
+		svc1 := NewConnectionService(true, bus)
+		svc2 := NewConnectionService(false, bus)
 
-	svc = NewConnectionService(false)
-	if svc.IsJSONMode() {
-		t.Error("Expected IsJSONMode() to return false")
-	}
-}
+		if !svc1.IsJSONMode() {
+			t.Error("Should return true when initialized with JSON mode")
+		}
 
-func TestSendInitialConfig(t *testing.T) {
-	mockConn := ssh.NewMockConnection()
+		if svc2.IsJSONMode() {
+			t.Error("Should return false when initialized without JSON mode")
+		}
+	})
 
-	svc := NewConnectionService(false)
+	t.Run("ConfigManagement", func(t *testing.T) {
+		bus := NewEventBus()
+		svc := NewConnectionService(false, bus)
 
-	cfg := config.Config{}
-	cfg.Application.Hostname = "test-host"
-	cfg.Application.Port = 8080
-	cfg.Agent.Tags = map[string]string{"env": "test"}
+		testConfig := config.Config{}
+		testConfig.Application.Hostname = "test-host"
+		testConfig.Application.Port = 8080
+		testConfig.Agent.Tags = map[string]string{"env": "test"}
 
-	err := svc.SendInitialConfig(mockConn, cfg)
-	if err != nil {
-		t.Errorf("Expected no error, got: %v", err)
-	}
+		svc.SetConfig(testConfig)
+		retrievedCfg := svc.GetConfig()
 
-	writtenData := mockConn.GetWrittenData()
-	if len(writtenData) == 0 {
-		t.Error("Expected data to be written, got empty buffer")
-	}
+		expected := []struct {
+			name     string
+			actual   interface{}
+			expected interface{}
+		}{
+			{"hostname", retrievedCfg.Application.Hostname, "test-host"},
+			{"port", retrievedCfg.Application.Port, 8080},
+			{"tags.env", retrievedCfg.Agent.Tags["env"], "test"},
+		}
 
-	testErr := errors.New("test error")
-	mockConn.SetSendPayloadError(testErr)
+		for _, e := range expected {
+			if e.actual != e.expected {
+				t.Errorf("Expected %s to be %v, got %v", e.name, e.expected, e.actual)
+			}
+		}
+	})
 
-	err = svc.SendInitialConfig(mockConn, cfg)
-	if err == nil {
-		t.Error("Expected error, got nil")
-	}
-}
+	t.Run("HasConnection", func(t *testing.T) {
+		bus := NewEventBus()
+		svc := NewConnectionService(false, bus)
 
-func TestConnectionServiceRun(t *testing.T) {
-	t.Skip("This test needs to be redesigned")
+		if svc.HasConnection() {
+			t.Error("New service should not have an active connection")
+		}
+	})
+
+	t.Run("SendConfig", func(t *testing.T) {
+		mockConn := ssh.NewMockConnection()
+		bus := NewEventBus()
+		svc := NewConnectionService(false, bus)
+
+		cfg := config.Config{}
+		cfg.Application.Hostname = "test-host"
+		cfg.Application.Port = 8080
+		cfg.Agent.Tags = map[string]string{"env": "test"}
+
+		if err := svc.sendConfig(mockConn, cfg); err != nil {
+			t.Errorf("Expected no error on send, got: %v", err)
+		}
+
+		writtenData := mockConn.GetWrittenData()
+		if len(writtenData) == 0 {
+			t.Error("No data was written to connection")
+		}
+
+		if !strings.Contains(string(writtenData), `"type":"config_update"`) {
+			t.Errorf("Expected config_update in payload, got: %s", string(writtenData))
+		}
+
+		testErr := errors.New("test error")
+		mockConn.SetSendPayloadError(testErr)
+
+		if err := svc.sendConfig(mockConn, cfg); err == nil {
+			t.Error("Expected error when connection fails")
+		}
+	})
+
+	t.Run("ServiceLifecycle", func(t *testing.T) {
+		bus := NewEventBus()
+		svc := NewConnectionService(false, bus)
+
+		ctx := context.Background()
+
+		if err := svc.Start(ctx); err != nil {
+			t.Errorf("Start should not return error, got: %v", err)
+		}
+
+		if err := svc.Stop(ctx); err != nil {
+			t.Errorf("Stop should not return error, got: %v", err)
+		}
+	})
+
+	t.Run("EventHandling", func(t *testing.T) {
+		bus := NewEventBus()
+		svc := NewConnectionService(false, bus)
+
+		// Need to start the service to initialize the context
+		ctx := context.Background()
+		if err := svc.Start(ctx); err != nil {
+			t.Fatalf("Failed to start service: %v", err)
+		}
+		defer func() { _ = svc.Stop(ctx) }()
+
+		reconnectCh := bus.Subscribe(ReconnectRequested, 1)
+
+		cfg := config.Config{}
+		cfg.Application.Hostname = "updated-host"
+		bus.Publish(Event{Type: ConfigUpdated, Data: cfg})
+
+		time.Sleep(10 * time.Millisecond) // Wait for processing
+		if svc.GetConfig().Application.Hostname != "updated-host" {
+			t.Error("Config should be updated after event")
+		}
+
+		select {
+		case <-reconnectCh:
+			// Expected behavior
+		case <-time.After(100 * time.Millisecond):
+			t.Error("Should have received reconnect event")
+		}
+	})
 }

--- a/internal/service/helpers.go
+++ b/internal/service/helpers.go
@@ -1,0 +1,15 @@
+package service
+
+import (
+	"os"
+)
+
+func drainSignals(ch <-chan os.Signal) {
+	for {
+		select {
+		case <-ch:
+		default:
+			return
+		}
+	}
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1,0 +1,130 @@
+package service
+
+import (
+	"context"
+	"sync"
+)
+
+type Service interface {
+	Start(ctx context.Context) error
+	Stop(ctx context.Context) error
+}
+
+type BaseService struct {
+	name   string
+	bus    *EventBus
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+func NewBaseService(name string, bus *EventBus) BaseService {
+	return BaseService{
+		name: name,
+		bus:  bus,
+	}
+}
+
+func (s *BaseService) Start(ctx context.Context) error {
+	s.ctx, s.cancel = context.WithCancel(ctx)
+	return nil
+}
+
+func (s *BaseService) Stop(ctx context.Context) error {
+	if s.cancel != nil {
+		s.cancel()
+	}
+	s.wg.Wait()
+	return nil
+}
+
+func (s *BaseService) Context() context.Context {
+	return s.ctx
+}
+
+func (s *BaseService) Go(f func()) {
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		f()
+	}()
+}
+
+type EventType string
+
+const (
+	ConfigUpdated         EventType = "config_updated"
+	ConnectionEstablished EventType = "connection_established"
+	ConnectionClosed      EventType = "connection_closed"
+	ConnectionFailed      EventType = "connection_failed"
+	ReconnectRequested    EventType = "reconnect_requested"
+	TerminationSignal     EventType = "termination_signal"
+)
+
+type Event struct {
+	Type EventType
+	Data interface{}
+}
+
+type EventBus struct {
+	listeners map[EventType][]chan Event
+	mu        sync.RWMutex
+}
+
+func NewEventBus() *EventBus {
+	return &EventBus{
+		listeners: make(map[EventType][]chan Event),
+	}
+}
+
+func (b *EventBus) Subscribe(eventType EventType, bufferSize int) <-chan Event {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	ch := make(chan Event, bufferSize)
+	b.listeners[eventType] = append(b.listeners[eventType], ch)
+	return ch
+}
+
+func (b *EventBus) SubscribeMultiple(eventTypes []EventType, bufferSize int) <-chan Event {
+	ch := make(chan Event, bufferSize)
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	for _, eventType := range eventTypes {
+		b.listeners[eventType] = append(b.listeners[eventType], ch)
+	}
+
+	return ch
+}
+
+func (b *EventBus) Publish(event Event) {
+	b.mu.RLock()
+	listeners, ok := b.listeners[event.Type]
+	b.mu.RUnlock()
+
+	if !ok {
+		return
+	}
+
+	for _, ch := range listeners {
+		select {
+		case ch <- event:
+		default:
+			// Channel full, skip this
+		}
+	}
+}
+
+func (b *EventBus) Close() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	for _, channels := range b.listeners {
+		for _, ch := range channels {
+			close(ch)
+		}
+	}
+	b.listeners = make(map[EventType][]chan Event)
+}

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -1,0 +1,117 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestBaseService(t *testing.T) {
+	bus := NewEventBus()
+	svc := NewBaseService("test", bus)
+
+	ctx := context.Background()
+	err := svc.Start(ctx)
+	if err != nil {
+		t.Errorf("Start returned error: %v", err)
+	}
+
+	if svc.Context() == nil {
+		t.Error("Context is nil after Start")
+	}
+
+	executed := make(chan struct{})
+	svc.Go(func() {
+		close(executed)
+	})
+
+	select {
+	case <-executed:
+		// Good
+	case <-time.After(100 * time.Millisecond):
+		t.Error("Go function was not executed")
+	}
+
+	err = svc.Stop(ctx)
+	if err != nil {
+		t.Errorf("Stop returned error: %v", err)
+	}
+}
+
+func TestEventBusPublishAndSubscribe(t *testing.T) {
+	bus := NewEventBus()
+
+	ch1 := bus.Subscribe("test_event", 1)
+	ch2 := bus.Subscribe("test_event", 1)
+	ch3 := bus.Subscribe("other_event", 1)
+
+	bus.Publish(Event{
+		Type: "test_event",
+		Data: "test data",
+	})
+
+	expectEvent(t, ch1, "test_event", "test data")
+	expectEvent(t, ch2, "test_event", "test data")
+	expectNoEvent(t, ch3)
+
+	bus.Publish(Event{
+		Type: "other_event",
+		Data: 123,
+	})
+
+	expectEvent(t, ch3, "other_event", 123)
+
+	bus.Close()
+
+	if _, ok := <-ch1; ok {
+		t.Error("Expected ch1 to be closed")
+	}
+	if _, ok := <-ch2; ok {
+		t.Error("Expected ch2 to be closed")
+	}
+	if _, ok := <-ch3; ok {
+		t.Error("Expected ch3 to be closed")
+	}
+}
+
+func TestEventBusSubscribeMultiple(t *testing.T) {
+	bus := NewEventBus()
+
+	events := []EventType{"event1", "event2", "event3"}
+	ch := bus.SubscribeMultiple(events, 3)
+
+	for _, eventType := range events {
+		bus.Publish(Event{
+			Type: eventType,
+			Data: string(eventType) + "_data",
+		})
+		expectEvent(t, ch, eventType, string(eventType)+"_data")
+	}
+
+	// Bus closed in TestEventBusPublishAndSubscribe
+}
+
+func expectEvent[T comparable](t *testing.T, ch <-chan Event, expectedType EventType, expectedData T) {
+	t.Helper()
+	select {
+	case event := <-ch:
+		if event.Type != expectedType {
+			t.Errorf("Expected event type %q, got %q", expectedType, event.Type)
+		}
+		if data, ok := event.Data.(T); !ok || data != expectedData {
+			t.Errorf("Expected event data %v, got %v", expectedData, event.Data)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Errorf("Timeout waiting for event of type %q", expectedType)
+	}
+}
+
+func expectNoEvent(t *testing.T, ch <-chan Event) {
+	t.Helper()
+	select {
+	case event := <-ch:
+		t.Errorf("Expected no event, but received: %v", event)
+	case <-time.After(100 * time.Millisecond):
+		// This is expected - no event should be received
+	}
+}

--- a/internal/ssh/ssh_test.go
+++ b/internal/ssh/ssh_test.go
@@ -13,13 +13,11 @@ import (
 func TestConnClose(t *testing.T) {
 	conn := &Conn{}
 
-	// First close should work fine
 	err := conn.Close()
 	if err != nil {
 		t.Errorf("First close returned error: %v", err)
 	}
 
-	// Second close should also work (idempotent operation)
 	err = conn.Close()
 	if err != nil {
 		t.Errorf("Second close returned error: %v", err)


### PR DESCRIPTION
This replaces the direct goroutine/channel management with a structured event bus for inter-service communication, similar to OTP application lifecycle. Closes #15